### PR TITLE
Fix conflict with other Windows SSH agents

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,7 @@ import (
 const (
 	WSL_SOCK    = "wincrypt-wsl.sock"
 	CYGWIN_SOCK = "wincrypt-cygwin.sock"
-	NAMED_PIPE  = "\\\\.\\pipe\\openssh-ssh-agent"
+	NAMED_PIPE  = "\\\\.\\pipe\\wincrypt-ssh-agent"
 	APP_CYGWIN  = iota
 	APP_WSL
 	APP_WINSSH


### PR DESCRIPTION
The \\.\pipe\openssh-ssh-agent named pipe is used by Windows SSH agents to provide SSH keys to SSH clients.  Several Windows SSH agents use this named pipe including the Windows native SSH agent, the 1Password SSH Agent, and WinCryptSSHAgent.  The problem is that only one of these can own the named pipe and therefore only one of these agents can be used at any given time.

I want to use the 1Password SSH agent and WinCryptSSHAgent simultaneously: the 1Password SSH agent for SSH keys stored in 1Password and WinCryptSSHAgent for keys stored in smart cards.

I only use the WSL 2 agent in WinCryptSSHAgent.  I don't use the Windows named pipe agent in WinCryptSSHAgent (\\.\pipe\openssh-ssh-agent).  Resolve this conflict by simply using a different named pipe (\\.\pipe\wincrypt-ssh-agent) for the Windows WinCryptSSHAgent.

Fixes rfdonnelly/WinCryptSSHAgent#1